### PR TITLE
Add 'Z Facebooku' section with last 3 Page posts

### DIFF
--- a/fb/package.json
+++ b/fb/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "publish": "bun run src/publish.ts",
     "auth": "bun run scripts/auth.ts",
-    "check": "bun run src/publish.ts --check"
+    "check": "bun run src/publish.ts --check",
+    "posts:fetch": "bun run scripts/fetch-posts.ts"
   },
   "devDependencies": {
     "@types/bun": "latest",

--- a/fb/scripts/fetch-posts.ts
+++ b/fb/scripts/fetch-posts.ts
@@ -1,0 +1,122 @@
+/**
+ * Fetch the N most recent posts authored by the Page and write them to
+ * /static/fb-posts.json (committed; served by GH Pages; consumed by the
+ * "Z Facebooku" section on the homepage).
+ *
+ * Usage:
+ *   cd fb
+ *   bun run posts:fetch                  # default: 3 posts → ../static/fb-posts.json
+ *   bun run posts:fetch --limit 5 --out ../static/fb-posts.json
+ *
+ * Then commit static/fb-posts.json and push. GH Pages will serve the
+ * updated payload on the next deploy.
+ *
+ * Token: same long-lived FACEBOOK_PAGE_ACCESS_TOKEN already in fb/.env
+ * from `bun run auth`. Only needs the pages_read_engagement scope (already
+ * granted alongside pages_manage_posts during the OAuth flow).
+ */
+import { writeFileSync, mkdirSync } from "node:fs";
+import { resolve, dirname } from "node:path";
+
+interface Args {
+  limit: number;
+  out: string;
+}
+
+interface GraphPost {
+  id: string;
+  message?: string;
+  created_time?: string;
+  permalink_url?: string;
+  full_picture?: string;
+}
+
+interface OutPost {
+  id: string;
+  text: string;
+  image: string | null;
+  url: string;
+  createdAt: string;
+}
+
+function parseArgs(argv: string[]): Args {
+  const a: Args = { limit: 3, out: resolve(process.cwd(), "..", "static", "fb-posts.json") };
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i]!;
+    switch (arg) {
+      case "--limit":
+      case "-n":
+        a.limit = Number(argv[++i] ?? "");
+        if (!Number.isFinite(a.limit) || a.limit < 1) die("--limit must be a positive integer");
+        break;
+      case "--out":
+      case "-o":
+        a.out = resolve(String(argv[++i] ?? ""));
+        break;
+      case "--help":
+      case "-h":
+        console.log(
+          "Usage: bun run posts:fetch [--limit N] [--out path]\n" +
+            "  --limit N    how many posts (default 3)\n" +
+            "  --out path   where to write JSON (default ../static/fb-posts.json)",
+        );
+        process.exit(0);
+      default:
+        die(`unknown argument: ${arg}`);
+    }
+  }
+  return a;
+}
+
+function die(msg: string): never {
+  console.error(`error: ${msg}`);
+  process.exit(2);
+}
+
+function env(name: string): string {
+  const v = process.env[name];
+  if (!v) die(`missing ${name} in environment (fb/.env)`);
+  return v;
+}
+
+async function main(): Promise<void> {
+  const args = parseArgs(process.argv.slice(2));
+  const pageId = env("FACEBOOK_PAGE_ID");
+  const token = env("FACEBOOK_PAGE_ACCESS_TOKEN");
+  const version = process.env.FACEBOOK_GRAPH_VERSION || "v21.0";
+
+  const url =
+    `https://graph.facebook.com/${version}/${encodeURIComponent(pageId)}/posts?` +
+    new URLSearchParams({
+      fields: "id,message,created_time,permalink_url,full_picture",
+      limit: String(args.limit),
+      access_token: token,
+    }).toString();
+
+  const res = await fetch(url);
+  const json = (await res.json().catch(() => ({}))) as { data?: GraphPost[]; error?: { message?: string } };
+  if (!res.ok) {
+    die(`Graph API ${res.status}: ${json?.error?.message ?? "unknown error"}`);
+  }
+
+  const posts: OutPost[] = (json.data ?? []).slice(0, args.limit).map((p) => ({
+    id: p.id,
+    text: (p.message ?? "").trim(),
+    image: p.full_picture ?? null,
+    url: p.permalink_url ?? `https://www.facebook.com/${p.id}`,
+    createdAt: p.created_time ?? "",
+  }));
+
+  mkdirSync(dirname(args.out), { recursive: true });
+  writeFileSync(args.out, JSON.stringify(posts, null, 2) + "\n");
+  console.log(`✓ wrote ${posts.length} post(s) → ${args.out}`);
+  for (const p of posts) {
+    const preview = (p.text || "(no text)").replace(/\s+/g, " ").slice(0, 70);
+    console.log(`  - ${p.createdAt.slice(0, 10)}  ${preview}${preview.length === 70 ? "…" : ""}`);
+  }
+}
+
+main().catch((err) => {
+  console.error("unhandled:", err instanceof Error ? err.stack ?? err.message : err);
+  process.exit(1);
+});

--- a/index.html
+++ b/index.html
@@ -335,14 +335,14 @@
   .fb-post.is-hero p{font-size:16px;flex:1}
   .fb-post.is-hero .more{padding-top:12px;border-top:1px solid var(--line);align-self:stretch}
 
-  /* mini cards — feed entries, square thumb on the left, text on the right */
-  .fb-post.is-mini{display:flex;align-items:stretch;flex:1 1 0;min-height:0;min-width:0}
-  .fb-post.is-mini .ph{flex:0 0 130px;align-self:stretch;background:var(--paper-2);position:relative;overflow:hidden;display:block}
-  .fb-post.is-mini .ph img{position:absolute;inset:0;width:100%;height:100%;object-fit:cover;display:block;transition:transform .4s}
+  /* mini cards — same vertical layout as the hero (photo on top, caption below), just smaller */
+  .fb-post.is-mini{display:flex;flex-direction:column;flex:1 1 0;min-height:0}
+  .fb-post.is-mini .ph{aspect-ratio:16/9;overflow:hidden;background:var(--paper-2);display:block}
+  .fb-post.is-mini .ph img{width:100%;height:100%;object-fit:cover;display:block;transition:transform .4s}
   .fb-post.is-mini:hover .ph img{transform:scale(1.03)}
-  .fb-post.is-mini .bd{flex:1 1 auto;min-width:0;padding:16px 18px;display:flex;flex-direction:column;gap:8px}
-  .fb-post.is-mini p{font-size:13.5px;display:-webkit-box;-webkit-line-clamp:3;-webkit-box-orient:vertical;overflow:hidden}
-  .fb-post.is-mini .more{margin-top:auto}
+  .fb-post.is-mini .bd{flex:1;padding:16px 18px 18px;display:flex;flex-direction:column;gap:10px;min-height:0}
+  .fb-post.is-mini p{font-size:13.5px;flex:1;display:-webkit-box;-webkit-line-clamp:2;-webkit-box-orient:vertical;overflow:hidden}
+  .fb-post.is-mini .more{padding-top:10px;border-top:1px solid var(--line);align-self:stretch}
 
   .fb-empty{font-family:var(--mono);font-size:13px;color:var(--muted);text-align:center;padding:24px 0}
 
@@ -426,7 +426,7 @@
     .fb-posts{grid-template-columns:1fr}
     .fb-post.is-hero .ph{aspect-ratio:16/10}
     .fb-post.is-hero .bd{padding:20px 22px 22px}
-    .fb-post.is-mini .ph{flex-basis:110px}
+    .fb-post.is-mini .ph{aspect-ratio:16/10}
     .form-row{grid-template-columns:1fr}
     .nav{gap:10px;height:64px;position:relative}
     .nav .links{

--- a/index.html
+++ b/index.html
@@ -426,6 +426,7 @@
     .fb-posts{grid-template-columns:1fr}
     .fb-post.is-hero .ph{aspect-ratio:16/10}
     .fb-post.is-hero .bd{padding:20px 22px 22px}
+    .fb-post.is-mini{flex:0 0 auto}
     .fb-post.is-mini .ph{aspect-ratio:16/10}
     .form-row{grid-template-columns:1fr}
     .nav{gap:10px;height:64px;position:relative}

--- a/index.html
+++ b/index.html
@@ -316,29 +316,31 @@
   .ref .who{font-family:var(--mono);font-size:12px;letter-spacing:.06em;color:var(--muted);border-top:1px solid var(--line);padding-top:14px}
   .ref .who b{color:var(--ink)}
 
-  /* asymmetric layout: 1 hero card on the left + 2 mini cards stacked on the right */
-  .fb-posts{display:grid;grid-template-columns:1.7fr 1fr;grid-auto-rows:1fr;gap:24px}
+  /* asymmetric layout: hero card on the left + a flex stack of 2 mini cards on the right */
+  .fb-posts{display:grid;grid-template-columns:1.7fr 1fr;gap:24px;align-items:stretch}
+  .fb-stack{display:flex;flex-direction:column;gap:24px;min-width:0}
   .fb-post{border:1px solid var(--line);background:#fff;overflow:hidden}
-  .fb-post .ph{overflow:hidden;background:var(--paper-2);display:block}
-  .fb-post .ph img{width:100%;height:100%;object-fit:cover;transition:transform .4s;display:block}
-  .fb-post:hover .ph img{transform:scale(1.03)}
   .fb-post .meta{font-family:var(--mono);font-size:11px;letter-spacing:.14em;color:var(--steel);text-transform:uppercase}
   .fb-post .meta .badge{margin-left:8px;color:var(--signal)}
   .fb-post p{color:#3c4148;line-height:1.55;white-space:pre-wrap;margin:0}
-  .fb-post .more{font-family:var(--mono);font-size:11px;letter-spacing:.1em;color:var(--steel);text-transform:uppercase;transition:.15s;display:inline-block}
+  .fb-post .more{font-family:var(--mono);font-size:11px;letter-spacing:.1em;color:var(--steel);text-transform:uppercase;transition:.15s;display:inline-block;align-self:flex-start}
   .fb-post .more:hover{color:var(--ink)}
 
-  /* hero card — spans both rows on the left, photo on top, big caption beneath */
-  .fb-post.is-hero{grid-column:1;grid-row:1 / span 2;display:flex;flex-direction:column}
-  .fb-post.is-hero .ph{aspect-ratio:4/3}
+  /* hero card — photo on top, big caption beneath */
+  .fb-post.is-hero{display:flex;flex-direction:column}
+  .fb-post.is-hero .ph{display:block;aspect-ratio:4/3;overflow:hidden;background:var(--paper-2)}
+  .fb-post.is-hero .ph img{width:100%;height:100%;object-fit:cover;display:block;transition:transform .4s}
+  .fb-post.is-hero:hover .ph img{transform:scale(1.03)}
   .fb-post.is-hero .bd{padding:26px 28px 28px;display:flex;flex-direction:column;gap:16px;flex:1}
   .fb-post.is-hero p{font-size:16px;flex:1}
-  .fb-post.is-hero .more{padding-top:12px;border-top:1px solid var(--line)}
+  .fb-post.is-hero .more{padding-top:12px;border-top:1px solid var(--line);align-self:stretch}
 
-  /* mini cards — compact feed entries, square thumb on the left, text on the right */
-  .fb-post.is-mini{display:grid;grid-template-columns:130px 1fr;align-items:stretch}
-  .fb-post.is-mini .ph{aspect-ratio:1/1;height:100%}
-  .fb-post.is-mini .bd{padding:16px 18px;display:flex;flex-direction:column;gap:8px;min-width:0}
+  /* mini cards — feed entries, square thumb on the left, text on the right */
+  .fb-post.is-mini{display:flex;align-items:stretch;flex:1 1 0;min-height:0;min-width:0}
+  .fb-post.is-mini .ph{flex:0 0 130px;align-self:stretch;background:var(--paper-2);position:relative;overflow:hidden;display:block}
+  .fb-post.is-mini .ph img{position:absolute;inset:0;width:100%;height:100%;object-fit:cover;display:block;transition:transform .4s}
+  .fb-post.is-mini:hover .ph img{transform:scale(1.03)}
+  .fb-post.is-mini .bd{flex:1 1 auto;min-width:0;padding:16px 18px;display:flex;flex-direction:column;gap:8px}
   .fb-post.is-mini p{font-size:13.5px;display:-webkit-box;-webkit-line-clamp:3;-webkit-box-orient:vertical;overflow:hidden}
   .fb-post.is-mini .more{margin-top:auto}
 
@@ -421,11 +423,10 @@
     .hero-inner,.about,.contact-grid{grid-template-columns:1fr;gap:36px}
     .hero-figure img{height:300px}
     .bikes,.svcs,.pkgs,.refs{grid-template-columns:1fr}
-    .fb-posts{grid-template-columns:1fr;grid-auto-rows:auto}
-    .fb-post.is-hero{grid-column:auto;grid-row:auto}
+    .fb-posts{grid-template-columns:1fr}
     .fb-post.is-hero .ph{aspect-ratio:16/10}
     .fb-post.is-hero .bd{padding:20px 22px 22px}
-    .fb-post.is-mini{grid-template-columns:110px 1fr}
+    .fb-post.is-mini .ph{flex-basis:110px}
     .form-row{grid-template-columns:1fr}
     .nav{gap:10px;height:64px;position:relative}
     .nav .links{
@@ -991,9 +992,8 @@
         lang === 'en' ? 'en-GB' : 'cs-CZ',
         { day: 'numeric', month: 'long', year: 'numeric' },
       );
-      grid.innerHTML = posts.slice(0, 3).map(function(p, idx){
-        var isHero = idx === 0;
-        var maxChars = isHero ? 420 : 130;
+      function card(p, isHero){
+        var maxChars = isHero ? 420 : 140;
         var d = p.createdAt ? new Date(p.createdAt) : null;
         var date = d && !isNaN(d.getTime()) ? fmt.format(d) : '';
         var raw = String(p.text || '');
@@ -1011,7 +1011,11 @@
           +   '<a class="more" href="' + escapeHtml(p.url) + '" target="_blank" rel="noopener">' + moreLabel + '</a>'
           + '</div>'
           + '</article>';
-      }).join('');
+      }
+      var slice = posts.slice(0, 3);
+      var hero = slice[0] ? card(slice[0], true) : '';
+      var minis = slice.slice(1).map(function(p){ return card(p, false); }).join('');
+      grid.innerHTML = hero + (minis ? '<div class="fb-stack">' + minis + '</div>' : '');
     }
     // Expose so applyLang can re-render without re-fetching.
     window.__renderFbPosts = function(lang){ render(lang); };

--- a/index.html
+++ b/index.html
@@ -316,16 +316,32 @@
   .ref .who{font-family:var(--mono);font-size:12px;letter-spacing:.06em;color:var(--muted);border-top:1px solid var(--line);padding-top:14px}
   .ref .who b{color:var(--ink)}
 
-  .fb-posts{display:grid;grid-template-columns:repeat(3,1fr);gap:24px}
-  .fb-post{border:1px solid var(--line);background:#fff;display:flex;flex-direction:column}
-  .fb-post .ph{aspect-ratio:1/1;overflow:hidden;background:var(--paper-2)}
-  .fb-post .ph img{width:100%;height:100%;object-fit:cover;transition:transform .4s}
+  /* asymmetric layout: 1 hero card on the left + 2 mini cards stacked on the right */
+  .fb-posts{display:grid;grid-template-columns:1.7fr 1fr;grid-auto-rows:1fr;gap:24px}
+  .fb-post{border:1px solid var(--line);background:#fff;overflow:hidden}
+  .fb-post .ph{overflow:hidden;background:var(--paper-2);display:block}
+  .fb-post .ph img{width:100%;height:100%;object-fit:cover;transition:transform .4s;display:block}
   .fb-post:hover .ph img{transform:scale(1.03)}
-  .fb-post .bd{padding:20px 22px 22px;display:flex;flex-direction:column;gap:12px;flex:1}
   .fb-post .meta{font-family:var(--mono);font-size:11px;letter-spacing:.14em;color:var(--steel);text-transform:uppercase}
-  .fb-post p{font-size:14.5px;color:#3c4148;flex:1;line-height:1.55;white-space:pre-wrap}
-  .fb-post .more{font-family:var(--mono);font-size:11px;letter-spacing:.1em;color:var(--steel);text-transform:uppercase;padding-top:10px;border-top:1px solid var(--line);transition:.15s}
+  .fb-post .meta .badge{margin-left:8px;color:var(--signal)}
+  .fb-post p{color:#3c4148;line-height:1.55;white-space:pre-wrap;margin:0}
+  .fb-post .more{font-family:var(--mono);font-size:11px;letter-spacing:.1em;color:var(--steel);text-transform:uppercase;transition:.15s;display:inline-block}
   .fb-post .more:hover{color:var(--ink)}
+
+  /* hero card — spans both rows on the left, photo on top, big caption beneath */
+  .fb-post.is-hero{grid-column:1;grid-row:1 / span 2;display:flex;flex-direction:column}
+  .fb-post.is-hero .ph{aspect-ratio:4/3}
+  .fb-post.is-hero .bd{padding:26px 28px 28px;display:flex;flex-direction:column;gap:16px;flex:1}
+  .fb-post.is-hero p{font-size:16px;flex:1}
+  .fb-post.is-hero .more{padding-top:12px;border-top:1px solid var(--line)}
+
+  /* mini cards — compact feed entries, square thumb on the left, text on the right */
+  .fb-post.is-mini{display:grid;grid-template-columns:130px 1fr;align-items:stretch}
+  .fb-post.is-mini .ph{aspect-ratio:1/1;height:100%}
+  .fb-post.is-mini .bd{padding:16px 18px;display:flex;flex-direction:column;gap:8px;min-width:0}
+  .fb-post.is-mini p{font-size:13.5px;display:-webkit-box;-webkit-line-clamp:3;-webkit-box-orient:vertical;overflow:hidden}
+  .fb-post.is-mini .more{margin-top:auto}
+
   .fb-empty{font-family:var(--mono);font-size:13px;color:var(--muted);text-align:center;padding:24px 0}
 
   .partners{padding:64px 0;border-top:1px solid var(--line);border-bottom:1px solid var(--line)}
@@ -405,6 +421,11 @@
     .hero-inner,.about,.contact-grid{grid-template-columns:1fr;gap:36px}
     .hero-figure img{height:300px}
     .bikes,.svcs,.pkgs,.refs{grid-template-columns:1fr}
+    .fb-posts{grid-template-columns:1fr;grid-auto-rows:auto}
+    .fb-post.is-hero{grid-column:auto;grid-row:auto}
+    .fb-post.is-hero .ph{aspect-ratio:16/10}
+    .fb-post.is-hero .bd{padding:20px 22px 22px}
+    .fb-post.is-mini{grid-template-columns:110px 1fr}
     .form-row{grid-template-columns:1fr}
     .nav{gap:10px;height:64px;position:relative}
     .nav .links{
@@ -965,21 +986,27 @@
       if(!Array.isArray(posts) || posts.length === 0){ section.hidden = true; return; }
       section.hidden = false;
       var moreLabel = (lang === 'en') ? 'View on Facebook →' : 'Otevřít na Facebooku →';
+      var latestBadge = (lang === 'en') ? 'LATEST' : 'NEJNOVĚJŠÍ';
       var fmt = new Intl.DateTimeFormat(
         lang === 'en' ? 'en-GB' : 'cs-CZ',
         { day: 'numeric', month: 'long', year: 'numeric' },
       );
-      grid.innerHTML = posts.slice(0, 3).map(function(p){
+      grid.innerHTML = posts.slice(0, 3).map(function(p, idx){
+        var isHero = idx === 0;
+        var maxChars = isHero ? 420 : 130;
         var d = p.createdAt ? new Date(p.createdAt) : null;
         var date = d && !isNaN(d.getTime()) ? fmt.format(d) : '';
         var raw = String(p.text || '');
-        var text = raw.length > 200 ? raw.slice(0, 200).trimEnd() + '…' : raw;
+        var text = raw.length > maxChars ? raw.slice(0, maxChars).trimEnd() + '…' : raw;
         var img = p.image
           ? '<a href="' + escapeHtml(p.url) + '" target="_blank" rel="noopener" class="ph"><img src="' + escapeHtml(p.image) + '" alt="" loading="lazy"></a>'
           : '';
-        return '<article class="fb-post">' + img
+        var meta = date
+          ? '<div class="meta">' + escapeHtml(date) + (isHero ? '<span class="badge">• ' + escapeHtml(latestBadge) + '</span>' : '') + '</div>'
+          : '';
+        return '<article class="fb-post ' + (isHero ? 'is-hero' : 'is-mini') + '">' + img
           + '<div class="bd">'
-          +   (date ? '<div class="meta">' + escapeHtml(date) + '</div>' : '')
+          +   meta
           +   '<p>' + escapeHtml(text) + '</p>'
           +   '<a class="more" href="' + escapeHtml(p.url) + '" target="_blank" rel="noopener">' + moreLabel + '</a>'
           + '</div>'

--- a/index.html
+++ b/index.html
@@ -316,6 +316,18 @@
   .ref .who{font-family:var(--mono);font-size:12px;letter-spacing:.06em;color:var(--muted);border-top:1px solid var(--line);padding-top:14px}
   .ref .who b{color:var(--ink)}
 
+  .fb-posts{display:grid;grid-template-columns:repeat(3,1fr);gap:24px}
+  .fb-post{border:1px solid var(--line);background:#fff;display:flex;flex-direction:column}
+  .fb-post .ph{aspect-ratio:1/1;overflow:hidden;background:var(--paper-2)}
+  .fb-post .ph img{width:100%;height:100%;object-fit:cover;transition:transform .4s}
+  .fb-post:hover .ph img{transform:scale(1.03)}
+  .fb-post .bd{padding:20px 22px 22px;display:flex;flex-direction:column;gap:12px;flex:1}
+  .fb-post .meta{font-family:var(--mono);font-size:11px;letter-spacing:.14em;color:var(--steel);text-transform:uppercase}
+  .fb-post p{font-size:14.5px;color:#3c4148;flex:1;line-height:1.55;white-space:pre-wrap}
+  .fb-post .more{font-family:var(--mono);font-size:11px;letter-spacing:.1em;color:var(--steel);text-transform:uppercase;padding-top:10px;border-top:1px solid var(--line);transition:.15s}
+  .fb-post .more:hover{color:var(--ink)}
+  .fb-empty{font-family:var(--mono);font-size:13px;color:var(--muted);text-align:center;padding:24px 0}
+
   .partners{padding:64px 0;border-top:1px solid var(--line);border-bottom:1px solid var(--line)}
   .partners .lbl{font-family:var(--mono);font-size:11px;letter-spacing:.18em;text-transform:uppercase;color:var(--muted);text-align:center;margin-bottom:30px}
   .plogos{display:flex;align-items:center;justify-content:center;gap:54px;flex-wrap:wrap}
@@ -377,6 +389,11 @@
   [data-theme="dark"] .pkg-intro{color:#E7E8E3}
   [data-theme="dark"] .btn-ink{background:#272E38}
   [data-theme="dark"] .btn-ink:hover{background:#323a47}
+  [data-theme="dark"] .fb-post{background:#1B2027;border-color:#2f3640}
+  [data-theme="dark"] .fb-post p{color:#d4d8de}
+  [data-theme="dark"] .fb-post .ph{background:#13161B}
+  [data-theme="dark"] .fb-post .more{border-top-color:#2f3640}
+  [data-theme="dark"] .fb-post .more:hover{color:#fff}
   [data-theme="dark"] .partners{border-top-color:#2f3640;border-bottom-color:#2f3640}
   [data-theme="dark"] .partners .lbl{color:#8b929b}
   [data-theme="dark"] .plogos img{filter:grayscale(1) invert(.85) opacity(.7)}
@@ -609,6 +626,15 @@
   </div>
 </section>
 
+<!-- FACEBOOK POSTS -->
+<section class="fb-section" id="fb-posts" hidden>
+  <div class="wrap">
+    <div class="sec-head"><span class="no">05</span><h2 data-i18n="fb.head">Z Facebooku</h2><span class="rule"></span><span class="tag" data-i18n="fb.tag">Co se u nás děje</span></div>
+    <div class="fb-posts" id="fb-posts-grid"></div>
+    <p class="fb-empty" id="fb-empty" hidden data-i18n="fb.empty">Žádné příspěvky nejsou k zobrazení.</p>
+  </div>
+</section>
+
 <!-- PARTNERS -->
 <div class="partners">
   <div class="wrap">
@@ -795,6 +821,10 @@
       'ref.1.body': '"A decent guy, pleasant small shop — none of the big-box service where you\'re just another number in the queue. Quick repair on the spot, an hour and a half before opening time."',
       'ref.2.body': "\"Great service and attitude. Third bike I've had serviced here and I've always been very satisfied.\"",
       'ref.3.body': '"Excellent bike service with no competition in the area. The right guy in the right place — exactly as it should be. Pricing and turnaround time both very fair."',
+      // facebook posts
+      'fb.head': 'From Facebook',
+      'fb.tag': "What's new",
+      'fb.empty': 'No posts to display.',
       // partners
       'partners.lbl': 'We work with the best',
       // contact
@@ -904,6 +934,8 @@
     }
     var themeBtn = document.getElementById('theme-toggle');
     if(themeBtn) themeBtn.setAttribute('aria-label', lang === 'en' ? 'Toggle dark mode' : 'Přepnout tmavý režim');
+    // Re-render the Facebook-posts section with the new language (no refetch).
+    if(typeof window.__renderFbPosts === 'function') window.__renderFbPosts(lang);
   }
 
   (function(){
@@ -916,6 +948,53 @@
       });
     });
     applyLang(initial);
+  })();
+
+  // Facebook posts — fetch ./static/fb-posts.json once, render, re-render on lang change.
+  (function(){
+    var section = document.getElementById('fb-posts');
+    var grid = document.getElementById('fb-posts-grid');
+    if(!section || !grid) return;
+    var posts = null;
+    function escapeHtml(s){
+      return String(s).replace(/[&<>"']/g, function(c){
+        return ({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'})[c];
+      });
+    }
+    function render(lang){
+      if(!Array.isArray(posts) || posts.length === 0){ section.hidden = true; return; }
+      section.hidden = false;
+      var moreLabel = (lang === 'en') ? 'View on Facebook →' : 'Otevřít na Facebooku →';
+      var fmt = new Intl.DateTimeFormat(
+        lang === 'en' ? 'en-GB' : 'cs-CZ',
+        { day: 'numeric', month: 'long', year: 'numeric' },
+      );
+      grid.innerHTML = posts.slice(0, 3).map(function(p){
+        var d = p.createdAt ? new Date(p.createdAt) : null;
+        var date = d && !isNaN(d.getTime()) ? fmt.format(d) : '';
+        var raw = String(p.text || '');
+        var text = raw.length > 200 ? raw.slice(0, 200).trimEnd() + '…' : raw;
+        var img = p.image
+          ? '<a href="' + escapeHtml(p.url) + '" target="_blank" rel="noopener" class="ph"><img src="' + escapeHtml(p.image) + '" alt="" loading="lazy"></a>'
+          : '';
+        return '<article class="fb-post">' + img
+          + '<div class="bd">'
+          +   (date ? '<div class="meta">' + escapeHtml(date) + '</div>' : '')
+          +   '<p>' + escapeHtml(text) + '</p>'
+          +   '<a class="more" href="' + escapeHtml(p.url) + '" target="_blank" rel="noopener">' + moreLabel + '</a>'
+          + '</div>'
+          + '</article>';
+      }).join('');
+    }
+    // Expose so applyLang can re-render without re-fetching.
+    window.__renderFbPosts = function(lang){ render(lang); };
+    fetch('./static/fb-posts.json', { cache: 'no-store' })
+      .then(function(r){ return r.ok ? r.json() : []; })
+      .then(function(data){
+        posts = Array.isArray(data) ? data : [];
+        render(document.documentElement.lang === 'en' ? 'en' : 'cs');
+      })
+      .catch(function(){ posts = []; section.hidden = true; });
   })();
 
   // Email obfuscation

--- a/index.html
+++ b/index.html
@@ -652,7 +652,7 @@
 <!-- FACEBOOK POSTS -->
 <section class="fb-section" id="fb-posts" hidden>
   <div class="wrap">
-    <div class="sec-head"><span class="no">05</span><h2 data-i18n="fb.head">Z Facebooku</h2><span class="rule"></span><span class="tag" data-i18n="fb.tag">Co se u nás děje</span></div>
+    <div class="sec-head"><span class="no">05</span><h2 data-i18n="fb.head">Z&nbsp;Facebooku</h2><span class="rule"></span><span class="tag" data-i18n="fb.tag">Co se u nás děje</span></div>
     <div class="fb-posts" id="fb-posts-grid"></div>
     <p class="fb-empty" id="fb-empty" hidden data-i18n="fb.empty">Žádné příspěvky nejsou k zobrazení.</p>
   </div>
@@ -845,7 +845,7 @@
       'ref.2.body': "\"Great service and attitude. Third bike I've had serviced here and I've always been very satisfied.\"",
       'ref.3.body': '"Excellent bike service with no competition in the area. The right guy in the right place — exactly as it should be. Pricing and turnaround time both very fair."',
       // facebook posts
-      'fb.head': 'From Facebook',
+      'fb.head': 'From&nbsp;Facebook',
       'fb.tag': "What's new",
       'fb.empty': 'No posts to display.',
       // partners

--- a/static/fb-posts.json
+++ b/static/fb-posts.json
@@ -1,0 +1,23 @@
+[
+  {
+    "id": "209739635725384_1162218195701983",
+    "text": "Jezdit a při tom ležet.... To je paráda! Ale udělat na tomto kole servis již taková paráda není 😉😋.",
+    "image": "https://scontent-fra3-1.xx.fbcdn.net/v/t39.30808-6/490551223_1162218232368646_8236637099041746232_n.jpg?stp=dst-jpg_p720x720_tt6&_nc_cat=105&ccb=1-7&_nc_sid=833d8c&_nc_ohc=U1E2wnbm1NoQ7kNvwHMJdLx&_nc_oc=AdqyHcWWwsqOMqiJo4BKMUB5qUesnj218NvlFuw9I8n4EitkSoW9lUdoNiaQYmVcMR0&_nc_zt=23&_nc_ht=scontent-fra3-1.xx&edm=AKIiGfEEAAAA&_nc_gid=0-F3uzRAGgNeoHForOpXow&_nc_tpa=Q5bMBQGDt9xLqal28Y0kgKfd3foea5OProZrVYE8RaE6yhcmPL20moQpRufvyPeGFM9s1RK02bdRvomPYg&oh=00_Af8DlCdu6iXF9Flm97K3OwjadltAV-WXlubd0oSghNItNA&oe=6A22352B",
+    "url": "https://www.facebook.com/1496367262287073/posts/1162218195701983",
+    "createdAt": "2025-04-17T09:20:30+0000"
+  },
+  {
+    "id": "209739635725384_1117094680214335",
+    "text": "Na dnešní vyjížďku jsem si připravil pořádné zbraně 😋.",
+    "image": "https://scontent-fra5-1.xx.fbcdn.net/v/t39.30808-6/485948085_1139102288013574_4877013657434856490_n.jpg?stp=dst-jpg_p720x720_tt6&_nc_cat=100&ccb=1-7&_nc_sid=833d8c&_nc_ohc=vRRHAhy2D68Q7kNvwEK1Fd_&_nc_oc=AdrdKiPv_VPGhdouD0dxF_sRCG59TiM4OlqxQ4U6dWEOVPSkPpF0sCZrk9diKAJ_28g&_nc_zt=23&_nc_ht=scontent-fra5-1.xx&edm=AKIiGfEEAAAA&_nc_gid=0-F3uzRAGgNeoHForOpXow&_nc_tpa=Q5bMBQF7S5ZtoPSRTYxN6SG-4l99AdJ2rSVDXRCe-KYweUGCHe10L21mqFTvPCrlwOUvacFM-Ag-v5seNA&oh=00_Af_13ZGwuIEyJJis0yF2a-TXa4uKawyvl6ZMKBd_Q_iogg&oe=6A224A54",
+    "url": "https://www.facebook.com/1496367262287073/posts/1117094680214335",
+    "createdAt": "2025-02-18T07:59:59+0000"
+  },
+  {
+    "id": "209739635725384_850486780208461",
+    "text": "Tak opět po roce 😋...",
+    "image": "https://scontent-fra3-2.xx.fbcdn.net/v/t39.30808-6/478189811_1113261490597654_5126430336859222242_n.jpg?stp=dst-jpg_p720x720_tt6&_nc_cat=104&ccb=1-7&_nc_sid=833d8c&_nc_ohc=PXAWMZU-jIsQ7kNvwHzdF73&_nc_oc=AdpraIE9wrg5Ai_Othw9T2_gJq3YXSo6raPej0ZF43GN6c2jGDclwQ9iL4Rdtfs3NBY&_nc_zt=23&_nc_ht=scontent-fra3-2.xx&edm=AKIiGfEEAAAA&_nc_gid=0-F3uzRAGgNeoHForOpXow&_nc_tpa=Q5bMBQFaJnTENG_yMzJXw8YeMKRmugmUKFh9EBblqk-b6CsrDTfAMke0YHVUbCk_n_Hk7Q3vmoRWmj2Sow&oh=00_Af88q11fVf0JbXTHRIBVmsHx_Qn5_vYTUTcorysATl0vHA&oe=6A2236C5",
+    "url": "https://www.facebook.com/1496367262287073/posts/850486780208461",
+    "createdAt": "2024-01-06T09:36:00+0000"
+  }
+]


### PR DESCRIPTION
## Summary

Adds a numbered section **05 — Z Facebooku** between References and Partners, showing the three most recent posts from the velointest Facebook Page with photo, date, text excerpt, and a link to the post.

## How it works

1. **Backend script** (`fb/scripts/fetch-posts.ts`, run as `bun run posts:fetch`):
   - Calls Graph API `/{page-id}/posts?fields=id,message,created_time,permalink_url,full_picture&limit=3`
   - Writes `static/fb-posts.json` (committed; served by GH Pages)
   - Manual cadence for now (run after publishing). GH Actions cron is a separate follow-up.

2. **Frontend** (inline in `index.html`):
   - Section starts `hidden`; JS fetches the JSON, caches it, renders the three cards
   - Re-renders on language change (date format flips between cs-CZ and en-GB, "Otevřít na Facebooku →" / "View on Facebook →")
   - Empty state hides the section entirely — no awkward "nothing here" box on the live page

## Design

Matches the workshop-blueprint aesthetic of the rest of the page:
- Same `sec-head` treatment (numbered, mono tag, rule line) as sections 01–04
- Square photo on top, mono date stamp, text excerpt with a mono "more →" link at the bottom of each card
- White card on light theme; slate (`#1B2027`) with `#2f3640` border in dark mode (same tokens the bike/pricing cards use)
- 3-column grid on desktop, stacks on mobile

## Preview

Will land on this PR as a comment in a moment via the preview workflow.

## How to keep it fresh

```bash
cd fb
bun run posts:fetch              # rewrites static/fb-posts.json
git add static/fb-posts.json
git commit -m "..."
git push
```

I can also chain this into a `publish-and-refresh` script if you want one-shot "post + section update + push", or add a daily cron via GH Actions.

## Test plan

- [ ] Visit the preview URL and confirm three FB-post cards render below the Reviews section, above Partners.
- [ ] Click a card photo and the "Otevřít na Facebooku →" link — both should open the post in a new tab.
- [ ] Toggle dark mode — cards flip to slate, text stays readable.
- [ ] Toggle EN — heading becomes "From Facebook", tag "What's new", date in `en-GB` format, link text "View on Facebook →".
- [ ] Hard-refresh in DevTools with `static/fb-posts.json` returning 404 — section stays hidden, no console error visible to users.
- [ ] At mobile width — cards stack to single column, photo + text legible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)