### PR TITLE
Cykloslužby copy refresh

### DIFF
--- a/index.html
+++ b/index.html
@@ -556,19 +556,19 @@
   <div class="grid-bg"></div>
   <div class="wrap">
     <div class="sec-head"><span class="no">02</span><h2 data-i18n="svc.head">Cykloslužby</h2><span class="rule"></span><span class="tag" data-i18n="svc.tag">Servis</span></div>
-    <p class="svc-intro" data-i18n="svc.intro">Servisujeme kola všech typů už <b><span data-since-year="1992">34</span> let</b> a disponujeme nepřekonatelným knowhow.</p>
+    <p class="svc-intro" data-i18n="svc.intro">Silnička, horské, gravel nebo elektro — co projede dveřmi, to spravíme. <b><span data-since-year="1992">34</span> let u ponku</b> a žádný díl nás nepřekvapí.</p>
     <div class="svcs">
       <article class="svc">
         <div class="ph"><img src="./static/bike-work-1-r.jpg" alt="Servis kola — oprava v dílně Velointest" loading="lazy"></div>
-        <div class="bd"><div class="num">SVC.01</div><h3 data-i18n="svc.1.title">Servis</h3><p data-i18n="svc.1.body">Opravíme vaše kolo.</p></div>
+        <div class="bd"><div class="num">SVC.01</div><h3 data-i18n="svc.1.title">Servis</h3><p data-i18n="svc.1.body">Od propíchlé duše po kompletní přestavbu pohonu. Diagnóza na rovinu, oprava, která vydrží. Řetěz vyměníme i na počkání.</p></div>
       </article>
       <article class="svc">
         <div class="ph"><img src="./static/bike-work-2-r.jpg" alt="Péče o kolo — sezónní servis" loading="lazy"></div>
-        <div class="bd"><div class="num">SVC.02</div><h3 data-i18n="svc.2.title">Péče o váš bike</h3><p data-i18n="svc.2.body">Dáme vaše kolo do pořádku po sezóně.</p></div>
+        <div class="bd"><div class="num">SVC.02</div><h3 data-i18n="svc.2.title">Péče o váš bike</h3><p data-i18n="svc.2.body">Sezónní prohlídka, vyčištění, seřízení. Na jaře nasednete na kolo jako nové, na zimu ho uložíte v kondici.</p></div>
       </article>
       <article class="svc">
         <div class="ph"><img src="./static/bike-work-3-r.jpg" alt="Konzultace a nastavení kola podle potřeb jezdce" loading="lazy"></div>
-        <div class="bd"><div class="num">SVC.03</div><h3 data-i18n="svc.3.title">Konzultace</h3><p data-i18n="svc.3.body">Nastavíme kolo podle vašich potřeb.</p></div>
+        <div class="bd"><div class="num">SVC.03</div><h3 data-i18n="svc.3.title">Konzultace</h3><p data-i18n="svc.3.body">Nevíte, co kolo potřebuje, nebo jestli se oprava ještě vyplatí? Řekneme to narovinu. Posed, výšku i převody vyladíme na vás, ne na katalog.</p></div>
       </article>
     </div>
   </div>
@@ -832,13 +832,13 @@
       // services
       'svc.head': 'Services',
       'svc.tag': 'Service',
-      'svc.intro': "We've been servicing all types of bikes for <b><span data-since-year=\"1992\">34</span> years</b> with unmatched know-how.",
+      'svc.intro': "Road, mountain, gravel or e-bike — if it rolls through the door, we'll fix it. <b><span data-since-year=\"1992\">34</span> years at the bench</b> and no part surprises us.",
       'svc.1.title': 'Repairs',
-      'svc.1.body': "We'll fix your bike.",
+      'svc.1.body': "From a punctured tube to a full drivetrain rebuild. Honest diagnosis, repairs that last. We'll even swap a chain while you wait.",
       'svc.2.title': 'Bike care',
-      'svc.2.body': "We'll get your bike ready after the season.",
+      'svc.2.body': 'Seasonal inspection, clean and tune. Ride a like-new bike in spring, store it in good shape for winter.',
       'svc.3.title': 'Consultation',
-      'svc.3.body': "We'll set your bike up to your needs.",
+      'svc.3.body': "Not sure what your bike needs, or whether a repair is still worth it? We'll tell you straight. Saddle, height and gearing dialed to you, not to a catalogue.",
       // packages
       'pkg.head': 'Service packages',
       'pkg.tag': 'Pricing',


### PR DESCRIPTION
Richer service-section copy in the workshop-blueprint voice, replacing the one-line descriptions. Approved by Pavel via WhatsApp; his edit ("Řetěz vyměníme i na počkání") is incorporated.

- Intro leads with bike types served, keeps the dynamic 34-years span
- SVC.01 / SVC.02 / SVC.03 bodies expanded; titles unchanged
- EN translations updated to match

🤖 Generated with [Claude Code](https://claude.com/claude-code)